### PR TITLE
レイキャストのバグ修正

### DIFF
--- a/cub_test_2.c
+++ b/cub_test_2.c
@@ -122,7 +122,6 @@ static int	has_collide(t_ray *ray, double t, t_matrix *world_map)
 	collide_x = collide->values[0][0]; //光の先端の座標
 	collide_y = collide->values[1][0];
 	//printf("collide_x:%f, y:%f\n", collide_x, collide_y);
-
 	double dist_next_x_side;
 	double dist_next_y_side;
 	if (mat_get_x(ray->dir->vector) > 0) // 光が+xの方向に進んでいる
@@ -149,19 +148,22 @@ static int	has_collide(t_ray *ray, double t, t_matrix *world_map)
 		//printf("collide_x        %f collide_y %f\n", collide_x, collide_y);
 		//printf("dist_next_x_side %f dist_next_y_side %f\n", dist_next_x_side, dist_next_y_side);
 
+		ray->collide_at_x = collide_x;
+		ray->collide_at_y = collide_y;
+
 		// mat_mul_scalar(-1, ray->from);
 		collide->values[0][0] -= ray->from->values[0][0]; // vectorをたす
 		collide->values[1][0] -= ray->from->values[1][0];
 
-		ray->v_distance = abs_double((mat_distance_2d(collide) * cos(ray->angle))
-							- (IMG_PLANE_LEN / (2 * tan(FOV / 2.0))));
+		ray->v_distance = abs_double(mat_distance_2d(collide) * cos(ray->angle));
+
 		if (world_map->values[(int)collide_y][(int)collide_x] == 2)
 			ray->color = BLUE;
 		else
 			ray->color = RED;
 
 		// xサイドを暗くする
-		if (side == X_SIDE) 
+		if (side == X_SIDE)
 		{
 			ray->color = create_trgb(get_t(ray->color),
 									get_r(ray->color) / 2,
@@ -188,7 +190,7 @@ static void	render_3d(t_window *window, t_ray *ray)
 	t_matrix	*center_of_line;
 
 	center_of_line = mat_vector_col_2d(RAY_NUM - ray->index - 1, WIN_H / 2);
-	line_length = (size_t)(H / (1.0 + ray->v_distance));
+	line_length = (size_t)(H / (ray->v_distance));
 	line_color = ray->color;
 	//printf("center:(%d, %d) length:%zu\n", (int)center_of_line->values[0][0], (int)center_of_line->values[0][1], line_length);
 	draw_line_v(window, center_of_line, line_length, line_color);

--- a/includes/cub3d.h
+++ b/includes/cub3d.h
@@ -6,7 +6,7 @@
 /*   By: iyamada <iyamada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/29 14:29:56 by kkaneko           #+#    #+#             */
-/*   Updated: 2022/04/05 11:48:03 by iyamada          ###   ########.fr       */
+/*   Updated: 2022/04/06 00:08:37 by iyamada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -125,6 +125,8 @@ typedef struct s_ray
 	double		v_distance;
 	int			color;
 	t_vector	*collision;
+	double		collide_at_x;
+	double		collide_at_y;
 	int	side;
 }	t_ray;
 

--- a/srcs/minimap/render_minimap.c
+++ b/srcs/minimap/render_minimap.c
@@ -6,7 +6,7 @@
 /*   By: iyamada <iyamada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/31 01:34:48 by kkaneko           #+#    #+#             */
-/*   Updated: 2022/04/04 17:40:17 by iyamada          ###   ########.fr       */
+/*   Updated: 2022/04/05 20:08:53 by iyamada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -186,7 +186,7 @@ static void	draw_circle(t_window *window, t_matrix *center, double r_max, int co
 
 void	draw_ray_on_minimap(t_window *window, t_ray *ray)
 {
-	const double	len_ray = 5;
+	const double	len_ray = ray->v_distance * 1;
 	const double	delta_t = 0.01;
 	double			plot_x;
 	double			plot_y;
@@ -206,6 +206,15 @@ void	draw_ray_on_minimap(t_window *window, t_ray *ray)
 				my_mlx_pixel_put(window->img_back, plot_x, plot_y, YELLOW);
 		}
 		t += delta_t;
+	}
+	// 衝突した座標をプロット
+	plot_x = ray->collide_at_x * MINIMAP_SIZE;
+	plot_y = ray->collide_at_y * MINIMAP_SIZE;
+	if (!idx_is_out_of_range(plot_x, WIN_W)
+		&& !idx_is_out_of_range(plot_y, WIN_H))
+	{
+		// printf("plot_x %f plot_y %f\n", plot_x, plot_y);
+		my_mlx_pixel_put(window->img_back, plot_x, plot_y, GREEN);
 	}
 }
 


### PR DESCRIPTION
# やったこと
- 壁とプレイヤーが近いときに正しく見えるようにした
  - 以前は壁の裏が見えるような不自然な感じだった。それを修正
- 光線の垂線の長さの計算式を修正した
  - ウィンドウの端に描画した壁が不自然な高さだった。それを修正
