### PR TITLE
fix makefile, main.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,8 @@ SRCS		+= handle_window.c \
 				mlx_wrapper.c \
 				vector.c
 
-OBJS		:= $(addprefix obj/, $(SRCS:.c=.o))
+OBJ_DIR		:= obj
+OBJS		:= $(addprefix $(OBJ_DIR)/, $(SRCS:.c=.o))
 DEPS		:= $(OBJS:.o=.d)
 
 # minilib
@@ -87,15 +88,18 @@ LIBFT_DIR	:= libft
 LIBFT_A		:= libft.a
 LIBFT_A		:= $(addprefix $(LIBFT_DIR)/, $(LIBFT_A))
 
-all: $(NAME)
-
 ifeq ($(shell uname), Linux)
-$(NAME): $(LIBFT_A) $(MLX_A) $(OBJS)
+$(NAME): $(LIBFT_A) $(MLX_A) $(OBJ_DIR) $(OBJS)
 	$(CC) -Wl,-start-group $(CFLAGS) $(COPTS) $(OBJS) -o $(NAME) -Wl,-end-group
 else ifeq ($(shell uname), Darwin)
-$(NAME): $(LIBFT_A) $(MLX_A) $(OBJS)
+$(NAME): $(LIBFT_A) $(MLX_A) $(OBJ_DIR) $(OBJS)
 	$(CC) $(CFLAGS) $(COPTS) $(OBJS) -o $(NAME)
 endif
+
+all: $(NAME)
+
+$(OBJ_DIR):
+	mkdir -p $@
 
 $(LIBFT_A): empty
 	make -C $(LIBFT_DIR)
@@ -105,16 +109,18 @@ empty:
 $(MLX_A): empty
 	make -C $(MLX_DIR)
 
-obj/%.o: %.c
+$(OBJ_DIR)/%.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@ -I include -I minilibx-linux -I libft -I /opt/X11/include
 
 clean:
-	rm -rf $(OBJS)
+	rm -rf $(OBJ_DIR)
+	rm -f norm_info
 	make -C $(LIBFT_DIR) clean
 	make -C $(MLX_DIR) clean
 
 fclean: clean
 	rm -rf $(NAME)
+	rm -rf $(MLX_A)
 	make -C $(LIBFT_DIR) fclean
 
 re:	fclean all
@@ -161,9 +167,9 @@ err: all
 
 norm:
 	norminette -v
-	norminette libft
-	norminette include
-	norminette src
+	norminette libft >> norm_info
+	norminette include >> norm_info
+	norminette src >> norm_info
 
 -include $(DEPS)
 

--- a/src/main.c
+++ b/src/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: iyamada <iyamada@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: kkaneko <kkaneko@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/23 01:58:18 by iyamada           #+#    #+#             */
-/*   Updated: 2022/05/25 01:45:33 by iyamada          ###   ########.fr       */
+/*   Updated: 2022/05/30 18:05:43 by kkaneko          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -74,4 +74,5 @@ int	main(int argc, char **argv)
 		return (1);
 	}
 	run(&cub);
+	return (0);
 }


### PR DESCRIPTION
<Makefile>
・前にobjディレクトリが残っている為レビューでKOになったケースを見たことがあったので、objディレクトリごと削除するようにしました。
・上に伴い、make時にobjディレクトリを作成するように修正しました
・make norm時に、norm_infoファイルに結果を吐き出し、grepできるようにしました(grep処理は、なぜかエラーになったので書いていません)。特に問題ありませんでした。

<main.c>
・最後にreturn 0;していない為コンパイルエラーになる問題を修正しました。